### PR TITLE
v4.0.1

### DIFF
--- a/src/Monq.Core.BasicDotNetMicroservice/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Monq.Core.BasicDotNetMicroservice/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using IdentityServer4.AccessTokenValidation;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -21,13 +20,11 @@ namespace Monq.Core.BasicDotNetMicroservice.Extensions
                 enableCaching = true;
 
             services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
-                .AddIdentityServerAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme, x =>
+                .AddOAuth2Introspection(IdentityServerAuthenticationDefaults.AuthenticationScheme, x =>
                 {
                     x.Authority = authConfig[AuthConstants.AuthenticationConfiguration.Authority];
-                    x.ApiName = authConfig[AuthConstants.AuthenticationConfiguration.ScopeName];
-                    x.ApiSecret = authConfig[AuthConstants.AuthenticationConfiguration.ScopeSecret];
-                    x.SupportedTokens = SupportedTokens.Both;
-                    x.RequireHttpsMetadata = requireHttps;
+                    x.ClientId = authConfig[AuthConstants.AuthenticationConfiguration.ScopeName];
+                    x.ClientSecret = authConfig[AuthConstants.AuthenticationConfiguration.ScopeSecret];
                     x.EnableCaching = enableCaching;
                     x.CacheDuration = TimeSpan.FromMinutes(5);
                     x.NameClaimType = "fullName";

--- a/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
+++ b/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
     <IsPackable>true</IsPackable>
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics.Prometheus" Version="4.2.0" />
+    <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="5.1.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Monq.Core.HttpClientExtensions" Version="4.0.0" />


### PR DESCRIPTION
Moved from deprecated `.AddIdentityServerAuthentication` to `.AddOAuth2Introspection` from IdentityModel 5.