### PR TITLE
BREAKING: Changed default HasTables() method in the `CreateDbSchemaOnFirstRun` extension

### DIFF
--- a/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
+++ b/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>6.7.0</Version>
+    <Version>6.7.1</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
     <IsPackable>true</IsPackable>
@@ -45,16 +45,17 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+		<PackageReference Include="Dapper" Version="2.0.123" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
@@ -62,10 +63,7 @@
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.NETCore.App" />
+		<PackageReference Include="Dapper" Version="2.0.123" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BREAKING: Changed default HasTables() method in the `CreateDbSchemaOnFirstRun` extension to raw sql PostreSQL request cause on cluster version HasTables()is not working properly. This method now only supports PostgreSql