### PR TITLE
MapApiVersionEndpoint AOT compatibility

### DIFF
--- a/src/Monq.Core.BasicDotNetMicroservice/Extensions/BasicMicroserviceConfigurationExtensions.cs
+++ b/src/Monq.Core.BasicDotNetMicroservice/Extensions/BasicMicroserviceConfigurationExtensions.cs
@@ -110,7 +110,6 @@ public static class BasicMicroserviceConfigurationExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <param name="anyEndpointType">Any type in startup assembly. Example: typeof(Program)</param>
-    [RequiresUnreferencedCode("Method uses minimal api MapGet which is incompatible with trimming.")]
     public static void MapApiVersion(this WebApplication app, Type anyEndpointType) =>
         app.MapGet("/api/version", () =>
         {

--- a/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
+++ b/src/Monq.Core.BasicDotNetMicroservice/Monq.Core.BasicDotNetMicroservice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>9.1.0</Version>
+    <Version>9.1.1</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
@@ -21,6 +21,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Nullable>enable</Nullable>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Remove [RequiresUnreferencedCode] from MapApiVersionEndpoint
- Set <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator> to remove minimal api extensions trimming issues.